### PR TITLE
update flake and add aarch64 architecture

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,10 @@ stdenv.mkDerivation {
   pname = "mmsg";
   version = "nightly";
 
-  src = ./.;
+  src = builtins.path {
+    path = ./.;
+    name = "source";
+  };
 
   nativeBuildInputs = [
     pkg-config
@@ -27,7 +30,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Maomaowm ipc client";
     homepage = "https://github.com/DreamMaoMao/mmsg";
-    maintainers = with lib.maintainers; [ ];
+    maintainers = [];
     mainProgram = "mmsg";
     platforms = lib.platforms.all;
   };

--- a/flake.nix
+++ b/flake.nix
@@ -4,23 +4,16 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
-  outputs =
-    {
-      flake-parts,
-      ...
-    }@inputs:
-    flake-parts.lib.mkFlake { inherit inputs; } {
-      perSystem =
-        { pkgs, ... }:
-        let
-          mmsg = pkgs.callPackage ./default.nix { };
-        in
-        {
-          packages = {
-            inherit mmsg;
-            default = mmsg;
-          };
+  outputs = {flake-parts, ...} @ inputs:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      perSystem = {pkgs, ...}: let
+        mmsg = pkgs.callPackage ./default.nix {};
+      in {
+        packages = {
+          inherit mmsg;
+          default = mmsg;
         };
-      systems = [ "x86_64-linux" ];
+      };
+      systems = ["x86_64-linux" "aarch64-linux"];
     };
 }


### PR DESCRIPTION
This patch adds `aarch64-linux` architecture for flake build, fixes warning about `builtins.path` (same as in `maomaowm` flake), and also formats nix code with alejandra.

`Aarch64-linux` build is successful and outputs properly compiled binary:

```bash
result/bin/mmsg: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /nix/store/m6a2ag1ji3kjacmbyxhdd60crwm3q0n8-glibc-2.40-66/lib/ld-linux-aarch64.so.1, for GNU/Linux 3.10.0, not stripped
```

I will update maomaowm flake to add aarch64 option.